### PR TITLE
ui: simplify context retrieval and fix bug

### DIFF
--- a/ui/src/calyptia/Core.tsx
+++ b/ui/src/calyptia/Core.tsx
@@ -146,8 +146,7 @@ export const Core = () => {
     }
   }, [])
   const createCoreInstance = async (
-    ddClient: v1.DockerDesktopClient,
-    args: string[]
+    ddClient: v1.DockerDesktopClient
   ) => {
     setCoreInstanceInfo(null)
 
@@ -161,6 +160,14 @@ export const Core = () => {
       return false
     }
 
+    let args = [
+      "create",
+      "core_instance",
+      "kubernetes",
+      "--token",
+      projectToken.token,
+    ]
+    
     let output = await hostCli(ddClient, "calyptia", args)
 
     if (output?.stderr) {
@@ -172,14 +179,7 @@ export const Core = () => {
 
   const uiCreateCoreInstance = async () => {
     try {
-      let args = [
-        "create",
-        "core_instance",
-        "kubernetes",
-        "--token",
-        projectToken.token,
-      ]
-      const isCreated = await createCoreInstance(client, args)
+      const isCreated = await createCoreInstance(client)
       if (isCreated) {
         client.desktopUI.toast.success("core instance creation successful")
       } else {


### PR DESCRIPTION
Remove polling for context which was not working on initial deployment and simplified by checking just prior to invoking creation.

Once https://github.com/calyptia/cli/issues/203 is implemented we can remove entirely and just create in the local cluster, similar to the current approach of retrieving using `kubectl` the core instance: https://github.com/calyptia/core-docker-desktop-extension/blob/d6826244c6f25b53fcc9eaf2b4797e553f280b1c/ui/src/calyptia/Core.tsx#L111-L118

Signed-off-by: Patrick Stephens <pat@calyptia.com>