### PR TITLE
workflows: provide correct permissions for release creation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,8 +76,11 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      # Need write access to create the release
+      contents: write
+      # Required for the signing token
       id-token: write
+      # Required to upload to ghcr.io
       packages: write
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Resolves incorrect permissions for auto-creating the Github release.

Signed-off-by: Patrick Stephens <pat@calyptia.com>