### PR TITLE
add dockerdesktop tag to instance

### DIFF
--- a/ui/src/lib/cloud.ts
+++ b/ui/src/lib/cloud.ts
@@ -39,6 +39,15 @@ export enum CoreInstanceStatus {
     unreachable = "unreachable",
 }
 
+export type UpdateCoreInstanceOpts = {
+    instanceID: string
+    payload: UpdateCoreInstancePayload
+}
+
+export type UpdateCoreInstancePayload = {
+    tags?: string[] | null
+}
+
 export class Client {
     constructor(private baseURL: string, private tokenSource: ReuseTokenSource) { }
 
@@ -97,6 +106,21 @@ export class Client {
             }
         })
         const json = await handleResp<CoreInstance>(resp)
+        return new HTTPRespose(json, resp)
+    }
+
+    async updateCoreInstance(signal: AbortSignal, opts: UpdateCoreInstanceOpts) {
+        const u = new URL("/v1/aggregators/" + encodeURIComponent(opts.instanceID), this.baseURL)
+        const tok = await this.tokenSource.token()
+        const resp = await fetch(u.toString(), {
+            signal,
+            method: "PATCH",
+            headers: {
+                Authorization: tok.tokenType + " " + tok.accessToken,
+            },
+            body: JSON.stringify(opts.payload),
+        })
+        const json = await handleResp<void>(resp)
         return new HTTPRespose(json, resp)
     }
 }


### PR DESCRIPTION
Adding `dockerdesktop` tag to core instances.

Notice that that tag is not `docker-desktop` as requested since cloud doesn't allow `-` https://github.com/calyptia/cloud/blob/e4ec00db9123eb4de890b943262d5543e10d292b/service.go#L83

Closes https://github.com/calyptia/core-docker-desktop-extension/issues/42