### PR TITLE
deploy instance with dockerdesktop tag

### DIFF
--- a/ui/src/components/CoreInstance.tsx
+++ b/ui/src/components/CoreInstance.tsx
@@ -80,7 +80,7 @@ function CoreInstanceView(props: CoreInstanceViewProps) {
                             {Array.isArray(props.coreInstance.tags) && props.coreInstance.tags.length !== 0 ? (
                                 <>
                                     <Typography sx={{ opacity: 0.7 }}>Tags</Typography>
-                                    <Stack alignItems="flex-start">{props.coreInstance.tags.map(tag => (
+                                    <Stack direction="row" gap={1}>{props.coreInstance.tags.map(tag => (
                                         <Chip key={tag} label={tag} />
                                     ))}</Stack>
                                 </>

--- a/ui/src/components/DeployCoreInstance.tsx
+++ b/ui/src/components/DeployCoreInstance.tsx
@@ -24,7 +24,7 @@ export default function DeployCoreInstance() {
             "core_instance",
             "kubernetes",
             "--token", projectToken.token,
-            "--tags", "dockerdesktop",
+            "--tags", "docker,desktop",
             "--kube-context", "docker-desktop"
         ]
 


### PR DESCRIPTION
Adding `dockerdesktop` tag to core instances.

Notice that that tag is not `docker-desktop` as requested since cloud doesn't allow `-` https://github.com/calyptia/cloud/blob/e4ec00db9123eb4de890b943262d5543e10d292b/service.go#L83

Closes https://github.com/calyptia/core-docker-desktop-extension/issues/42