### PR TITLE
Use "proxy" package.json field to work around cloud origin block

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -18,11 +18,12 @@
     "react-scripts": "5.0.0"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "REACT_APP_CLOUD_BASE_URL=http://localhost:3000 react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
+  "proxy": "https://cloud-api.calyptia.com",
   "eslintConfig": {
     "extends": [
       "react-app",


### PR DESCRIPTION
This is required to work around CORS block from cloud-api.calyptia.com when running the extension in development mode:
![image](https://user-images.githubusercontent.com/842846/196680052-4a77e5d5-7ba7-45a6-8c06-aca20e80e2a0.png)
