### PR TITLE
ui: switch to production YAML

### DIFF
--- a/ui/src/components/DeleteCoreInstance.tsx
+++ b/ui/src/components/DeleteCoreInstance.tsx
@@ -41,15 +41,12 @@ export default function DeleteCoreInstance(props: Props) {
         }
 
         const args = [
-            "delete", "--ignore-not-found",
-            "--kube-context", "docker-desktop",
-            "-f", "https://storage.googleapis.com/calyptia_public_resources_bucket/docker-desktop/vivo-k8s.yaml"
+            "delete", 
+            "deployments,services,pods", 
+            "-l", "app.kubernetes.io/name=vivo",
+            "--context", "docker-desktop",
         ]
-
-        const output = await dd.extension.host.cli.exec("kubectl", args)
-        if (output.stderr !== "") {
-            throw new Error(output.stderr)
-        }
+        await dd.extension.host.cli.exec("kubectl", args)
     }
 
     const deleteCoreInstance = async () => {

--- a/ui/src/components/DeployCoreInstance.tsx
+++ b/ui/src/components/DeployCoreInstance.tsx
@@ -22,7 +22,7 @@ export default function DeployCoreInstance() {
         const args = [
             "apply",
             "--context", "docker-desktop",
-            "-f", "https://storage.googleapis.com/calyptia_public_resources_bucket/docker-desktop/vivo-k8s.yaml"
+            "-f", "https://raw.githubusercontent.com/calyptia/vivo/master/vivo.yaml"
         ]
 
         const output = await dd.extension.host.cli.exec("kubectl", args)


### PR DESCRIPTION
Uses public repo YAML now to create the service and deployment for Vivo.
Forcibly deletes all pods, services and deployments for Vivo.

Signed-off-by: Patrick Stephens <pat@calyptia.com>