### PR TITLE
vivo: Implement filtering

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -23,10 +23,12 @@
         "react-scripts": "5.0.0"
       },
       "devDependencies": {
+        "@codemirror/lang-json": "^6.0.0",
         "@docker/extension-api-client-types": "^0.2.3",
         "@types/jest": "^27.5.1",
         "@types/node": "^17.0.35",
         "@types/react-dom": "^17.0.2",
+        "@uiw/react-codemirror": "^4.12.4",
         "typescript": "^4.6.4"
       }
     },
@@ -1824,6 +1826,111 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.3.0.tgz",
+      "integrity": "sha512-4jEvh3AjJZTDKazd10J6ZsCIqaYxDMCeua5ouQxY8hlFIml+nr7le0SgBhT3SIytFBmdzPK3AUhXGuW3T79nVg==",
+      "dev": true,
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.1.2.tgz",
+      "integrity": "sha512-sO3jdX1s0pam6lIdeSJLMN3DQ6mPEbM4yLvyKkdqtmd/UDwhXA5+AwFJ89rRXm6vTeOXBsE5cAmlos/t7MJdgg==",
+      "dev": true,
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-json": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-json/-/lang-json-6.0.0.tgz",
+      "integrity": "sha512-DvTcYTKLmg2viADXlTdufrT334M9jowe1qO02W28nvm+nejcvhM5vot5mE8/kPrxYw/HJHhwu1z2PyBpnMLCNQ==",
+      "dev": true,
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/json": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.2.1.tgz",
+      "integrity": "sha512-MC3svxuvIj0MRpFlGHxLS6vPyIdbTr2KKPEW46kCoCXw2ktb4NTkpkPBI/lSP/FoNXLCBJ0mrnUi1OoZxtpW1Q==",
+      "dev": true,
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.0.0.tgz",
+      "integrity": "sha512-nUUXcJW1Xp54kNs+a1ToPLK8MadO0rMTnJB8Zk4Z8gBdrN0kqV7uvUraU/T2yqg+grDNR38Vmy/MrhQN/RgwiA==",
+      "dev": true,
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/search": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.2.2.tgz",
+      "integrity": "sha512-2pWY599zXk+lSoJ2iv9EuTO4gB7lhgBPLPwFb/zTbimFH4NmZSaKzJSV51okjABZ7/Rj0DYy5klWbIgaJh2LoQ==",
+      "dev": true,
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.1.2.tgz",
+      "integrity": "sha512-Mxff85Hp5va+zuj+H748KbubXjrinX/k28lj43H14T2D0+4kuvEFIEIO7hCEcvBT8ubZyIelt9yGOjj2MWOEQA==",
+      "dev": true
+    },
+    "node_modules/@codemirror/theme-one-dark": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.0.tgz",
+      "integrity": "sha512-AiTHtFRu8+vWT9wWUWDM+cog6ZwgivJogB1Tm/g40NIpLwph7AnmxrSzWfvJN5fBVufsuwBxecQCNmdcR5D7Aw==",
+      "dev": true,
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/highlight": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.4.0.tgz",
+      "integrity": "sha512-Kv32b6Tn7QVwFbj/EDswTLSocjk5kgggF6zzBFAL4o4hZ/vmtFD155+EjH1pVlbfoDyVC2M6SedPsMrwYscgNg==",
+      "dev": true,
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "style-mod": "^4.0.0",
+        "w3c-keyname": "^2.2.4"
+      }
+    },
     "node_modules/@csstools/normalize.css": {
       "version": "12.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-12.0.0.tgz",
@@ -3104,6 +3211,40 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
+    },
+    "node_modules/@lezer/common": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.0.1.tgz",
+      "integrity": "sha512-8TR5++Q/F//tpDsLd5zkrvEX5xxeemafEaek7mUp7Y+bI8cKQXdSqhzTOBaOogETcMOVr0pT3BBPXp13477ciw==",
+      "dev": true
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.1.2.tgz",
+      "integrity": "sha512-CAun1WR1glxG9ZdOokTZwXbcwB7PXkIEyZRUMFBVwSrhTcogWq634/ByNImrkUnQhjju6xsIaOBIxvcRJtplXQ==",
+      "dev": true,
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/json": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@lezer/json/-/json-1.0.0.tgz",
+      "integrity": "sha512-zbAuUY09RBzCoCA3lJ1+ypKw5WSNvLqGMtasdW6HvVOqZoCpPr8eWrsGnOVWGKGn8Rh21FnrKRVlJXrGAVUqRw==",
+      "dev": true,
+      "dependencies": {
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.2.3.tgz",
+      "integrity": "sha512-qpB7rBzH8f6Mzjv2AVZRahcm+2Cf7nbIH++uXbvVOL1yIRvVWQ3HAM/saeBLCyz/togB7LGo76qdJYL1uKQlqA==",
+      "dev": true,
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
     },
     "node_modules/@mui/base": {
       "version": "5.0.0-alpha.101",
@@ -4482,6 +4623,53 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@uiw/codemirror-extensions-basic-setup": {
+      "version": "4.12.4",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-extensions-basic-setup/-/codemirror-extensions-basic-setup-4.12.4.tgz",
+      "integrity": "sha512-owSCcRBtS2wYjxgBFkuIjfjWJHsR8AxgsQtqPpHB/6U0zCLuzKS/OM5ZRS2T3rdOizg0hCPztVvmshWeKjF+qw==",
+      "dev": true,
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      },
+      "peerDependencies": {
+        "@codemirror/autocomplete": ">=6.0.0",
+        "@codemirror/commands": ">=6.0.0",
+        "@codemirror/language": ">=6.0.0",
+        "@codemirror/lint": ">=6.0.0",
+        "@codemirror/search": ">=6.0.0",
+        "@codemirror/state": ">=6.0.0",
+        "@codemirror/view": ">=6.0.0"
+      }
+    },
+    "node_modules/@uiw/react-codemirror": {
+      "version": "4.12.4",
+      "resolved": "https://registry.npmjs.org/@uiw/react-codemirror/-/react-codemirror-4.12.4.tgz",
+      "integrity": "sha512-92TAvN2z5snPjPtJDLmbqrqsXXYFYlBnWraXZuDc1XGaw80tB26ZkdEW79CD2QM4Y9LhFIt+sauwlmiAVDs/5A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.18.6",
+        "@codemirror/commands": "^6.1.0",
+        "@codemirror/state": "^6.1.1",
+        "@codemirror/theme-one-dark": "^6.0.0",
+        "@uiw/codemirror-extensions-basic-setup": "4.12.4",
+        "codemirror": "^6.0.0"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.11.0",
+        "@codemirror/state": ">=6.0.0",
+        "@codemirror/theme-one-dark": ">=6.0.0",
+        "@codemirror/view": ">=6.0.0",
+        "codemirror": ">=6.0.0",
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
@@ -5753,6 +5941,21 @@
         "node": ">= 4.0"
       }
     },
+    "node_modules/codemirror": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.1.tgz",
+      "integrity": "sha512-J8j+nZ+CdWmIeFIGXEFbFPtpiYacFMDR8GlHK3IyHQJMCaVRfGx9NT+Hxivv1ckLWPvNdZqndbr/7lVhrf/Svg==",
+      "dev": true,
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      }
+    },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz",
@@ -5995,6 +6198,12 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/crelt": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.5.tgz",
+      "integrity": "sha512-+BO9wPPi+DWTDcNYhr/W90myha8ptzftZT+LwcmUbbok0rcP/fequmFYCw8NMoH7pkAZQzU78b3kYrlua5a9eA==",
+      "dev": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -15273,6 +15482,12 @@
         "webpack": "^5.0.0"
       }
     },
+    "node_modules/style-mod": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.0.0.tgz",
+      "integrity": "sha512-OPhtyEjyyN9x3nhPsu76f52yUGXiZcgvsrFVtvTkyGRQJ0XK+GPc6ov1z+lRpbeabka+MYEQxOYRnt5nF30aMw==",
+      "dev": true
+    },
     "node_modules/stylehacks": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-5.1.0.tgz",
@@ -16025,6 +16240,12 @@
       "dependencies": {
         "browser-process-hrtime": "^1.0.0"
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.6.tgz",
+      "integrity": "sha512-f+fciywl1SJEniZHD6H+kUO8gOnwIr7f4ijKA6+ZvJFjeGi1r4PDLl53Ayud9O/rk64RqgoQine0feoeOU0kXg==",
+      "dev": true
     },
     "node_modules/w3c-xmlserializer": {
       "version": "2.0.0",
@@ -18133,6 +18354,105 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
+    "@codemirror/autocomplete": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.3.0.tgz",
+      "integrity": "sha512-4jEvh3AjJZTDKazd10J6ZsCIqaYxDMCeua5ouQxY8hlFIml+nr7le0SgBhT3SIytFBmdzPK3AUhXGuW3T79nVg==",
+      "dev": true,
+      "requires": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "@codemirror/commands": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.1.2.tgz",
+      "integrity": "sha512-sO3jdX1s0pam6lIdeSJLMN3DQ6mPEbM4yLvyKkdqtmd/UDwhXA5+AwFJ89rRXm6vTeOXBsE5cAmlos/t7MJdgg==",
+      "dev": true,
+      "requires": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "@codemirror/lang-json": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-json/-/lang-json-6.0.0.tgz",
+      "integrity": "sha512-DvTcYTKLmg2viADXlTdufrT334M9jowe1qO02W28nvm+nejcvhM5vot5mE8/kPrxYw/HJHhwu1z2PyBpnMLCNQ==",
+      "dev": true,
+      "requires": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/json": "^1.0.0"
+      }
+    },
+    "@codemirror/language": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.2.1.tgz",
+      "integrity": "sha512-MC3svxuvIj0MRpFlGHxLS6vPyIdbTr2KKPEW46kCoCXw2ktb4NTkpkPBI/lSP/FoNXLCBJ0mrnUi1OoZxtpW1Q==",
+      "dev": true,
+      "requires": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "@codemirror/lint": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.0.0.tgz",
+      "integrity": "sha512-nUUXcJW1Xp54kNs+a1ToPLK8MadO0rMTnJB8Zk4Z8gBdrN0kqV7uvUraU/T2yqg+grDNR38Vmy/MrhQN/RgwiA==",
+      "dev": true,
+      "requires": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "@codemirror/search": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.2.2.tgz",
+      "integrity": "sha512-2pWY599zXk+lSoJ2iv9EuTO4gB7lhgBPLPwFb/zTbimFH4NmZSaKzJSV51okjABZ7/Rj0DYy5klWbIgaJh2LoQ==",
+      "dev": true,
+      "requires": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "@codemirror/state": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.1.2.tgz",
+      "integrity": "sha512-Mxff85Hp5va+zuj+H748KbubXjrinX/k28lj43H14T2D0+4kuvEFIEIO7hCEcvBT8ubZyIelt9yGOjj2MWOEQA==",
+      "dev": true
+    },
+    "@codemirror/theme-one-dark": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.0.tgz",
+      "integrity": "sha512-AiTHtFRu8+vWT9wWUWDM+cog6ZwgivJogB1Tm/g40NIpLwph7AnmxrSzWfvJN5fBVufsuwBxecQCNmdcR5D7Aw==",
+      "dev": true,
+      "requires": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/highlight": "^1.0.0"
+      }
+    },
+    "@codemirror/view": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.4.0.tgz",
+      "integrity": "sha512-Kv32b6Tn7QVwFbj/EDswTLSocjk5kgggF6zzBFAL4o4hZ/vmtFD155+EjH1pVlbfoDyVC2M6SedPsMrwYscgNg==",
+      "dev": true,
+      "requires": {
+        "@codemirror/state": "^6.0.0",
+        "style-mod": "^4.0.0",
+        "w3c-keyname": "^2.2.4"
+      }
+    },
     "@csstools/normalize.css": {
       "version": "12.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-12.0.0.tgz",
@@ -19012,6 +19332,40 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
+    },
+    "@lezer/common": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.0.1.tgz",
+      "integrity": "sha512-8TR5++Q/F//tpDsLd5zkrvEX5xxeemafEaek7mUp7Y+bI8cKQXdSqhzTOBaOogETcMOVr0pT3BBPXp13477ciw==",
+      "dev": true
+    },
+    "@lezer/highlight": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.1.2.tgz",
+      "integrity": "sha512-CAun1WR1glxG9ZdOokTZwXbcwB7PXkIEyZRUMFBVwSrhTcogWq634/ByNImrkUnQhjju6xsIaOBIxvcRJtplXQ==",
+      "dev": true,
+      "requires": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "@lezer/json": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@lezer/json/-/json-1.0.0.tgz",
+      "integrity": "sha512-zbAuUY09RBzCoCA3lJ1+ypKw5WSNvLqGMtasdW6HvVOqZoCpPr8eWrsGnOVWGKGn8Rh21FnrKRVlJXrGAVUqRw==",
+      "dev": true,
+      "requires": {
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "@lezer/lr": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.2.3.tgz",
+      "integrity": "sha512-qpB7rBzH8f6Mzjv2AVZRahcm+2Cf7nbIH++uXbvVOL1yIRvVWQ3HAM/saeBLCyz/togB7LGo76qdJYL1uKQlqA==",
+      "dev": true,
+      "requires": {
+        "@lezer/common": "^1.0.0"
+      }
     },
     "@mui/base": {
       "version": "5.0.0-alpha.101",
@@ -19894,6 +20248,35 @@
       "requires": {
         "@typescript-eslint/types": "5.39.0",
         "eslint-visitor-keys": "^3.3.0"
+      }
+    },
+    "@uiw/codemirror-extensions-basic-setup": {
+      "version": "4.12.4",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-extensions-basic-setup/-/codemirror-extensions-basic-setup-4.12.4.tgz",
+      "integrity": "sha512-owSCcRBtS2wYjxgBFkuIjfjWJHsR8AxgsQtqPpHB/6U0zCLuzKS/OM5ZRS2T3rdOizg0hCPztVvmshWeKjF+qw==",
+      "dev": true,
+      "requires": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      }
+    },
+    "@uiw/react-codemirror": {
+      "version": "4.12.4",
+      "resolved": "https://registry.npmjs.org/@uiw/react-codemirror/-/react-codemirror-4.12.4.tgz",
+      "integrity": "sha512-92TAvN2z5snPjPtJDLmbqrqsXXYFYlBnWraXZuDc1XGaw80tB26ZkdEW79CD2QM4Y9LhFIt+sauwlmiAVDs/5A==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.18.6",
+        "@codemirror/commands": "^6.1.0",
+        "@codemirror/state": "^6.1.1",
+        "@codemirror/theme-one-dark": "^6.0.0",
+        "@uiw/codemirror-extensions-basic-setup": "4.12.4",
+        "codemirror": "^6.0.0"
       }
     },
     "@webassemblyjs/ast": {
@@ -20866,6 +21249,21 @@
         "q": "^1.1.2"
       }
     },
+    "codemirror": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.1.tgz",
+      "integrity": "sha512-J8j+nZ+CdWmIeFIGXEFbFPtpiYacFMDR8GlHK3IyHQJMCaVRfGx9NT+Hxivv1ckLWPvNdZqndbr/7lVhrf/Svg==",
+      "dev": true,
+      "requires": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      }
+    },
     "collect-v8-coverage": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz",
@@ -21051,6 +21449,12 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/cra-template/-/cra-template-1.1.3.tgz",
       "integrity": "sha512-HThWiYybjc47tP6pV8WSEIG4lZ85Qps9rmw45ILRlnrUmCKSCWANWwSZf9HU4UbJSJ1zkpHyVka5HLSEANIOqQ=="
+    },
+    "crelt": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.5.tgz",
+      "integrity": "sha512-+BO9wPPi+DWTDcNYhr/W90myha8ptzftZT+LwcmUbbok0rcP/fequmFYCw8NMoH7pkAZQzU78b3kYrlua5a9eA==",
+      "dev": true
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -27579,6 +27983,12 @@
       "integrity": "sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==",
       "requires": {}
     },
+    "style-mod": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.0.0.tgz",
+      "integrity": "sha512-OPhtyEjyyN9x3nhPsu76f52yUGXiZcgvsrFVtvTkyGRQJ0XK+GPc6ov1z+lRpbeabka+MYEQxOYRnt5nF30aMw==",
+      "dev": true
+    },
     "stylehacks": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-5.1.0.tgz",
@@ -28134,6 +28544,12 @@
       "requires": {
         "browser-process-hrtime": "^1.0.0"
       }
+    },
+    "w3c-keyname": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.6.tgz",
+      "integrity": "sha512-f+fciywl1SJEniZHD6H+kUO8gOnwIr7f4ijKA6+ZvJFjeGi1r4PDLl53Ayud9O/rk64RqgoQine0feoeOU0kXg==",
+      "dev": true
     },
     "w3c-xmlserializer": {
       "version": "2.0.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -30,10 +30,12 @@
     ]
   },
   "devDependencies": {
+    "@codemirror/lang-json": "^6.0.0",
     "@docker/extension-api-client-types": "^0.2.3",
     "@types/jest": "^27.5.1",
     "@types/node": "^17.0.35",
     "@types/react-dom": "^17.0.2",
+    "@uiw/react-codemirror": "^4.12.4",
     "typescript": "^4.6.4"
   }
 }

--- a/ui/src/components/CoreInstance.tsx
+++ b/ui/src/components/CoreInstance.tsx
@@ -130,6 +130,7 @@ export default function CoreInstance(props: Props) {
                   setViewData={setViewData}
                   clearRecords={clearRecords}
                   changeFilter={filterChanged}
+                  filter={filterRecords.filter}
                   filteredRecords={filterRecords.filtered}/>
         )
     }

--- a/ui/src/components/Vivo.tsx
+++ b/ui/src/components/Vivo.tsx
@@ -12,7 +12,7 @@ import { useEffect, useState } from 'react'
 import CodeMirror from '@uiw/react-codemirror';
 import { json } from '@codemirror/lang-json';
 import {linter, Diagnostic} from "@codemirror/lint"
-import { jsonToFilter, applyVivoFilter, Filter } from '../lib/filter'
+import { stringToIncludes, applyVivoFilter, Filter } from '../lib/filter'
 
 import {
   VivoConnection, VivoStdoutEventData,
@@ -48,12 +48,12 @@ export default function Vivo({
     return filterDiagnostics
   }
 
-  function jsonFilterChanged(json: string) {
-    if (json.trim() === '') {
+  function filterChanged(fstr: string) {
+    if (fstr.trim() === '') {
       return changeFilter(null);
     }
     try {
-      const filter = jsonToFilter(json);
+      const filter = stringToIncludes(fstr);
       changeFilter(filter);
       setFilterDiagnostics([])
     } catch (err) {
@@ -122,7 +122,7 @@ export default function Vivo({
       <CodeMirror
         maxHeight="100px"
         height="auto"
-        onChange={jsonFilterChanged}
+        onChange={filterChanged}
         extensions={[json(), linter(linterCallback)]}
         basicSetup={{ lineNumbers: false }}/>
       <FluentBitData connection={connection} records={getRecords()} />

--- a/ui/src/components/Vivo.tsx
+++ b/ui/src/components/Vivo.tsx
@@ -12,7 +12,7 @@ import { useEffect, useState } from 'react'
 import CodeMirror from '@uiw/react-codemirror';
 import { json } from '@codemirror/lang-json';
 import {linter, Diagnostic} from "@codemirror/lint"
-import { jsonToFilter, Filter } from '../lib/filter'
+import { jsonToFilter, applyVivoFilter, Filter } from '../lib/filter'
 
 import {
   VivoConnection, VivoStdoutEventData,
@@ -25,6 +25,7 @@ interface VivoProps {
   clearRecords: () => void
   changeFilter: (filter: Filter | null) => void
   filteredRecords: VivoStdoutEventData[]
+  filter: Filter | null
 }
 
 function exampleFluentBitCommand(port: number) {
@@ -36,7 +37,7 @@ function exampleCurlCommand(port: number) {
 }
 
 export default function Vivo({
-  connection, records, setViewData, clearRecords, filteredRecords, changeFilter
+  connection, records, setViewData, clearRecords, filteredRecords, changeFilter, filter
 }: VivoProps) {
   const [currentPort, setCurrentPort] = useState(connection.currentPort())
   const [pausedRecords, setPausedRecords] = useState<VivoStdoutEventData[] | null>(null);
@@ -83,7 +84,7 @@ export default function Vivo({
 
   function getRecords() {
     if (pausedRecords) {
-      return pausedRecords
+      return filter && filterEnabled ? applyVivoFilter(filter, pausedRecords) : pausedRecords
     }
 
     if (filterEnabled) {

--- a/ui/src/lib/filter.test.ts
+++ b/ui/src/lib/filter.test.ts
@@ -1,0 +1,120 @@
+import { applyFilter, jsonToFilter } from './filter'
+
+describe('applyFilter', () => {
+  const data = [
+    {date: 0, log: "line 0"},
+    {date: 1, log: "line 1"},
+    {date: 2, log: "line 2"},
+    {date: 3, log: "line 3"},
+    {date: 4, log: "line 4"},
+    {date: 5, log: "line 5"},
+    {date: 6, log: "line 6"},
+    {date: 7, log: "line 7"},
+    {date: 8, log: "line 8"},
+    {date: 9, log: "line 9"},
+  ] as Record<string, unknown>[]
+
+
+  it('handles empty and/or filters', () => {
+    expect(applyFilter({ or: [] }, data)).toEqual([]);
+    expect(applyFilter({ and: [] }, data)).toEqual(data);
+  })
+
+  it('accepts "equals" filters', () => {
+    expect(applyFilter({ key: "date", equals: 2 }, data)).toEqual([
+      {date: 2, log: "line 2"}
+    ]);
+    expect(applyFilter({ key: "log", equals: "line 7" }, data)).toEqual([
+      {date: 7, log: "line 7"}
+    ]);
+  })
+
+  it('accepts "regex" filters', () => {
+    expect(applyFilter({ key: "log", matches: /LINE (7|8|9)/i }, data)).toEqual([
+      {date: 7, log: "line 7"},
+      {date: 8, log: "line 8"},
+      {date: 9, log: "line 9"},
+    ]);
+  })
+
+  it('accepts "or" filters', () => {
+    expect(applyFilter({or: [
+      { key: "date", equals: 2 },
+      { key: "log", equals: "line 7" },
+    ]}, data)).toEqual([
+      {date: 2, log: "line 2"},
+      {date: 7, log: "line 7"}
+    ]);
+
+    expect(applyFilter({or: [
+      { key: "date", equals: "2" },
+      { key: "log", equals: "line 7" },
+    ]}, data)).toEqual([
+      {date: 7, log: "line 7"}
+    ]);
+  });
+
+  it('accepts "and" filters', () => {
+    expect(applyFilter({and: [
+      { key: "date", equals: 2 },
+      { key: "log", equals: "line 2" },
+    ]}, data)).toEqual([
+      {date: 2, log: "line 2"},
+    ]);
+
+    expect(applyFilter({and: [
+      { key: "date", equals: 2 },
+      { key: "log", equals: "line 7" },
+    ]}, data)).toEqual([]);
+  });
+
+  it('accepts nested filters', () => {
+    const filter = {
+      or: [
+        { key: "date", equals: 1 },
+        { and: [
+          { key: "log", matches: /line (3|5)$/ },
+          { key: "date", equals: 5 }
+          ]
+        },
+        { key: "log", matches: /(7|6)/ },
+      ]
+    }
+    expect(applyFilter(filter, data)).toEqual([
+      {date: 1, log: "line 1"},
+      {date: 5, log: "line 5"},
+      {date: 6, log: "line 6"},
+      {date: 7, log: "line 7"},
+    ]);
+  });
+})
+
+describe('jsonToFilter', () => {
+  it('converts a json string to a filter object', () => {
+    const filter = {
+      or: [
+        { key: "date", equals: 1 },
+        { and: [
+          { key: "log", matches: /line (3|5)$/i },
+          { key: "date", equals: 5 }
+          ]
+        },
+        { key: "log", matches: /(7|6)/ },
+      ]
+    }
+
+    const json = `{
+      "or": [
+        { "key": "date", "equals": 1 },
+        { "and": [
+          { "key": "log", "matches": "line (3|5)$", "flags": "i" },
+          { "key": "date", "equals": 5 }
+          ]
+        },
+        { "key": "log", "matches": "(7|6)" }
+      ]
+    }`
+
+    expect(jsonToFilter(json)).toEqual(filter);
+  });
+});

--- a/ui/src/lib/filter.ts
+++ b/ui/src/lib/filter.ts
@@ -1,0 +1,109 @@
+import type { VivoStdoutEventData, } from './vivo'
+
+interface Equals {
+  key: string
+  equals: unknown
+}
+
+interface Regex {
+  key: string
+  matches: RegExp
+}
+
+interface Or {
+  or: Filter[]
+}
+
+interface And {
+  and: Filter[]
+}
+
+export type Filter = Equals | Regex | Or | And
+
+function recordMatchesEquals(equals: Equals, record: Record<string, unknown>): boolean {
+  const value = record[equals.key]
+  if (value == null) {
+    return false
+  }
+  return value === equals.equals
+}
+
+function recordMatchesRegex(regex: Regex, record: Record<string, unknown>): boolean {
+  const value = record[regex.key]
+  if (typeof value !== 'string') {
+    return false;
+  }
+  return regex.matches.test(value)
+}
+
+function recordMatchesOr(or: Or, record: Record<string, unknown>): boolean {
+  let rv = false
+
+  for (const f of or.or) {
+    rv = rv || recordMatchesFilter(f, record)
+    if (rv) {
+      break;
+    }
+  }
+
+  return rv;
+}
+
+function recordMatchesAnd(and: And, record: Record<string, unknown>): boolean {
+  let rv = true;
+
+  for (const f of and.and) {
+    rv = rv && recordMatchesFilter(f, record)
+    if (!rv) {
+      break;
+    }
+  }
+
+  return rv;
+}
+
+export function recordMatchesFilter(filter: Filter, record: Record<string, unknown>): boolean {
+  if ('or' in filter) {
+    return recordMatchesOr(filter, record);
+  } else if ('and' in filter) {
+    return recordMatchesAnd(filter, record);
+  } else if ('matches' in filter) {
+    return recordMatchesRegex(filter, record);
+  } else {
+    return recordMatchesEquals(filter, record);
+  }
+}
+
+export function applyFilter(filter: Filter, records: Record<string, unknown>[]) {
+  return records.filter(r => recordMatchesFilter(filter, r));
+}
+
+export function applyVivoFilter(filter: Filter, records: VivoStdoutEventData[]) {
+  return records.filter(r => recordMatchesFilter(filter, r.data));
+}
+
+// Temporary hack that allows users to type in a filter without creating a proper query language
+export function jsonToFilter(json: string): Filter {
+  const parsed: unknown = JSON.parse(json);
+
+  function convert(obj: unknown): Filter {
+    if (Array.isArray(obj['or'])) {
+      return { or: obj['or'].map(convert) }
+    } else if (Array.isArray(obj['and'])) {
+      return { and: obj['and'].map(convert) }
+    } else if (typeof obj !== 'object') {
+      throw new Error(`Invalid filter "${JSON.stringify(obj)}"`)
+    } else if (typeof obj['key'] === 'string' && typeof obj['matches'] === 'string') {
+      if (typeof obj['flags'] !== 'string' && obj['flags'] != null) {
+        throw new Error('Invalid type for Regex "flags"')
+      }
+      return { key: obj['key'], matches: new RegExp(obj['matches'], obj['flags'] || '') }
+    } else if (typeof obj['key'] === 'string' && 'equals' in obj) {
+      return { key: obj['key'], equals: obj['equals'] }
+    } else {
+      throw new Error(`Invalid filter "${JSON.stringify(obj)}"`)
+    }
+  }
+
+  return convert(parsed);
+}


### PR DESCRIPTION
This implements a simple form of filtering concept though a json query language. We can improve upon this later by creating a parser which creates a proper query language into an AST (right now only the AST is implemented)

Examples: 

```js
// filter records where the "log" key matches the regexp "12:20
{"key": "log", "matches": "12:20"}
// filter records where the "name" record equals "dummy"
{"key": "name", "equals": "dummy"}
// combine both filters above using an "or" operation
{"or": [{"key": "log", "matches": "12:20"}, {"key": "name", "equals": "dummy"}]}
```

cc @edsiper @agup006 

* update: As Eduardo suggested, I've implemented a simple filtering mechanism to search in all keys/values whatever is typed in the search box