### PR TITLE
make sure to logout from auth0 on email not verified

### DIFF
--- a/ui/src/components/AuthGuard.tsx
+++ b/ui/src/components/AuthGuard.tsx
@@ -47,6 +47,7 @@ export default function AuthGuard(props: PropsWithChildren<AuthGuardProps>) {
             const usr = await auth.fetchUserInfo(ctrl.signal, tok)
 
             if (usr.email_verified !== true) {
+                dd.host.openExternal(auth.buildLogoutURL())
                 throw new Error("email not verified. You will get a verification email to verify your account")
             }
 

--- a/ui/src/components/Header.tsx
+++ b/ui/src/components/Header.tsx
@@ -33,8 +33,8 @@ export default function Header() {
 
     const onLogout = () => {
         localStorage.clear()
-        window.location.reload()
         dd.host.openExternal(auth.buildLogoutURL())
+        window.location.reload()
     }
 
     return (

--- a/ui/src/hooks/project-token.tsx
+++ b/ui/src/hooks/project-token.tsx
@@ -4,12 +4,16 @@ import Box from "@mui/material/Box"
 import LinearProgress from "@mui/material/LinearProgress"
 import { createContext, PropsWithChildren, useContext, useEffect, useState } from "react"
 import { Token } from "../lib/cloud"
+import { useAuthClient } from "./auth"
 import { useCloudClient } from "./cloud"
+import { useDockerDesktopClient } from "./docker-desktop"
 
 const ProjectTokenContext = createContext(null as unknown as Token)
 
 export function ProjectTokenProvider(props: PropsWithChildren<unknown>) {
     const cloud = useCloudClient()
+    const dd = useDockerDesktopClient()
+    const auth = useAuthClient()
     const [tok, setTok] = useState<Token | null>(null)
     const [err, setErr] = useState<Error | null>(null)
 
@@ -42,6 +46,7 @@ export function ProjectTokenProvider(props: PropsWithChildren<unknown>) {
             // backward-compatible fix for users that did login without a verified email.
             if (err.message === "email not verified") {
                 localStorage.clear()
+                dd.host.openExternal(auth.buildLogoutURL())
                 window.location.reload()
             }
 


### PR DESCRIPTION
Fixes an issue were the user could not be able to change auth mechanism or account after getting `email not verified` error.

Now it correctly logs the user out from auth0 so it can select another account, or auth mechanism (email or social providers).

The only drawback is that it will open a browser window when logging-out.
I'll explore how to do it so it doesn't open the browser in a future PR.