### PR TITLE
ui: authorize timeout counter and keep link on page

### DIFF
--- a/ui/src/components/AuthGuard.tsx
+++ b/ui/src/components/AuthGuard.tsx
@@ -3,7 +3,7 @@ import { useAuthClient } from "../hooks/auth"
 import { CloudClientProvider } from "../hooks/cloud"
 import { useDockerDesktopClient } from "../hooks/docker-desktop"
 import { UserInfoProvider } from "../hooks/user-info"
-import { ReuseTokenSource, Token, tokenFromJSON, UserInfo } from "../lib/auth"
+import { DeviceCode, ReuseTokenSource, Token, tokenFromJSON, UserInfo } from "../lib/auth"
 import LoginScreen from "./LoginScreen"
 
 export type AuthGuardProps = {
@@ -16,6 +16,7 @@ export default function AuthGuard(props: PropsWithChildren<AuthGuardProps>) {
     const [userInfo, setUserInfo] = useState<UserInfo | null>(null)
     const [tokenSource, setTokenSource] = useState<ReuseTokenSource | null>(null)
     const [loading, setLoading] = useState(false)
+    const [deviceCode, setDeviceCode] = useState<DeviceCode | null>(null)
 
     const setTokenSourceFromTok = (tok: Token) => {
         const ctrl = new AbortController()
@@ -41,6 +42,7 @@ export default function AuthGuard(props: PropsWithChildren<AuthGuardProps>) {
         const ctrl = new AbortController()
         try {
             const dc = await auth.fetchDeviceCode(ctrl.signal)
+            setDeviceCode(dc)
             dd.host.openExternal(dc.verificationURIComplete)
 
             const tok = await dc.fetchToken(ctrl.signal)
@@ -63,6 +65,7 @@ export default function AuthGuard(props: PropsWithChildren<AuthGuardProps>) {
         } finally {
             ctrl.abort()
             setLoading(false)
+            setDeviceCode(null)
         }
     }
 
@@ -75,6 +78,6 @@ export default function AuthGuard(props: PropsWithChildren<AuthGuardProps>) {
     }
 
     return (
-        <LoginScreen loading={loading} onLoginClick={login} />
+        <LoginScreen loading={loading} devideCode={deviceCode} onLoginClick={login} />
     )
 }

--- a/ui/src/components/LoginScreen.tsx
+++ b/ui/src/components/LoginScreen.tsx
@@ -2,13 +2,17 @@ import AbcIcon from '@mui/icons-material/Abc'
 import LoadingButton from "@mui/lab/LoadingButton"
 import Box from "@mui/material/Box"
 import Button from "@mui/material/Button"
+import Link from "@mui/material/Link"
 import Paper from "@mui/material/Paper"
 import Typography from "@mui/material/Typography"
+import { useEffect, useState } from "react"
 import { useDockerDesktopClient } from "../hooks/docker-desktop"
 import logoLightSrc from "../images/logo-light.svg"
+import { DeviceCode } from "../lib/auth"
 
 export type LoginScreenProps = {
     loading: boolean
+    devideCode: DeviceCode | null
     onLoginClick: () => void | Promise<void>
 }
 
@@ -35,8 +39,25 @@ export default function LoginScreen(props: LoginScreenProps) {
                 <Typography color="#1669aa" variant="h5">Observability, simplified.</Typography>
                 <Typography color="#0d3d61" variant="body1">Eliminate the complexity of configuring and maintaining your observability pipelines.</Typography>
                 {props.loading ? (
-                    // AbcIcon is there only to take space so the text doesn't overlay with the loader indicator.
-                    <LoadingButton loading loadingPosition="start" variant="outlined" startIcon={<AbcIcon />} >Waiting authorization</LoadingButton>
+                    <>
+                        {/* AbcIcon is there only to take space so the text doesn't overlay with the loader indicator. */}
+                        <LoadingButton loading loadingPosition="start" variant="outlined" startIcon={<AbcIcon />} >
+                            <span>Waiting authorization</span>
+                            {props.devideCode !== null ? (
+                                <Box ml={1}>
+                                    <CountDown date={props.devideCode.expiry} />
+                                </Box>
+                            ) : null}
+                        </LoadingButton>
+                        {props.devideCode !== null ? (
+                            <Box>
+                                <Typography textAlign="center" variant="caption">Or Visit:</Typography>{" "}
+                                <Link component="button" textAlign="center" onClick={() => {
+                                    dd.host.openExternal(props.devideCode.verificationURIComplete)
+                                }}>{props.devideCode.verificationURIComplete}</Link>
+                            </Box>
+                        ) : null}
+                    </>
                 ) : (
                     <Button variant="contained" color="primary" sx={{ mt: 2, backgroundColor: "#1669aa" }} onClick={props.onLoginClick}>LOG IN WITH BROWSER</Button>
                 )}
@@ -66,5 +87,35 @@ export default function LoginScreen(props: LoginScreenProps) {
                 </Paper>
             </Box>
         </Box >
+    )
+}
+
+type CountDownProps = {
+    date: Date
+}
+
+function CountDown(props: CountDownProps) {
+    const calcDates = () => {
+        const now = new Date()
+        const d = props.date.valueOf() - now.valueOf()
+        return {
+            minutes: Math.max(Math.floor((d % (1000 * 60 * 60)) / (1000 * 60)), 0),
+            seconds: Math.max(Math.floor((d % (1000 * 60)) / 1000), 0),
+        }
+    }
+
+    const [dates, setDates] = useState(calcDates)
+
+    useEffect(() => {
+        const id = setInterval(() => {
+            setDates(calcDates())
+        }, 1000)
+        return () => {
+            clearInterval(id)
+        }
+    }, [props.date])
+
+    return (
+        <time>{dates.minutes}:{dates.seconds}</time>
     )
 }

--- a/ui/src/lib/auth.ts
+++ b/ui/src/lib/auth.ts
@@ -10,7 +10,7 @@ export type DeviceCodeResponse = {
     interval: number  // seconds
 }
 
-class DeviceCode {
+export class DeviceCode {
     deviceCode = ""
     userCode = ""
     verificationURI = ""


### PR DESCRIPTION
Adding authorization timeout counter.
Also added a link to the autorization page in case the user closed the tab.

Closes https://github.com/calyptia/core-docker-desktop-extension/issues/62