### PR TITLE
Vivo UI styled card wrapper

### DIFF
--- a/ui/src/components/StyledCard.tsx
+++ b/ui/src/components/StyledCard.tsx
@@ -12,9 +12,9 @@ export type CardProps = {
 export default function StyledCard(props: PropsWithChildren<CardProps>) {
     return (
         <MCard elevation={0} sx={{ border: "1px solid rgba(63, 81, 181, 0.14)" }}>
-            {props.title ? 
-            <CardHeader title={props.title} subheader={props.subheader} action={props.action} sx={{ bgcolor: "rgba(63, 81, 181, 0.08)" }} titleTypographyProps={{ color: "#0D3D61", fontSize: "20px", fontWeight: 700 }} subheaderTypographyProps={{ color: "#0D3D61", fontSize: "14px", mt: 1 }} />
-            : <></>}
+            {props.title ?
+                <CardHeader title={props.title} subheader={props.subheader} action={props.action} sx={{ bgcolor: "rgba(63, 81, 181, 0.08)" }} titleTypographyProps={{ color: "#0D3D61", fontSize: "20px", fontWeight: 700 }} subheaderTypographyProps={{ color: "#0D3D61B3", fontSize: "14px", mt: 1 }} />
+                : <></>}
             <CardContent sx={{ bgcolor: "white" }} children={props.children} />
         </MCard>
     )

--- a/ui/src/components/Vivo.tsx
+++ b/ui/src/components/Vivo.tsx
@@ -125,7 +125,7 @@ export default function Vivo({
         </> : null}
 
         <Stack direction="row" alignItems="center" justifyContent="space-between" mb={1}>
-          <ButtonGroup variant="text">
+          <ButtonGroup variant="outlined">
             <Button sx={{ width: "calc(8ch + 2rem)" }} onClick={togglePause}>{pausedRecords ? "Continue" : "Pause"}</Button>
             <Button sx={{ width: "calc(8ch + 2rem)" }} onClick={clear}>{"Clear"}</Button>
           </ButtonGroup>

--- a/ui/src/components/Vivo.tsx
+++ b/ui/src/components/Vivo.tsx
@@ -124,14 +124,14 @@ export default function Vivo({
           <SampleCommands port={currentPort} />
         </> : null}
 
-        <Stack direction="row" alignItems="center" justifyContent="space-between" mb={1}>
+        <Stack direction="row" alignItems="center" justifyContent="flex-end" mb={1}>
+          <FormControlLabel label="Filter" control={(
+            <Switch checked={filterEnabled} onChange={e => setFilterEnabled(e.target.checked)} />
+          )} />
           <ButtonGroup variant="outlined">
             <Button sx={{ width: "calc(8ch + 2rem)" }} onClick={togglePause}>{pausedRecords ? "Continue" : "Pause"}</Button>
             <Button sx={{ width: "calc(8ch + 2rem)" }} onClick={clear}>{"Clear"}</Button>
           </ButtonGroup>
-          <FormControlLabel label="Filter" control={(
-            <Switch checked={filterEnabled} onChange={e => setFilterEnabled(e.target.checked)} />
-          )} />
         </Stack>
 
         {filterEnabled && (

--- a/ui/src/components/Vivo.tsx
+++ b/ui/src/components/Vivo.tsx
@@ -124,31 +124,29 @@ export default function Vivo({
           <SampleCommands port={currentPort} />
         </> : null}
 
-        <ButtonGroup>
-          <Button variant="contained" sx={{ backgroundColor: "#1669AA", width: "calc(8ch + 2rem)" }} onClick={togglePause}>{pausedRecords ? "Continue" : "Pause"}</Button>
-          <Button variant="contained" sx={{ backgroundColor: "#1669AA", width: "calc(8ch + 2rem)" }} onClick={clear}>{"Clear"}</Button>
-        </ButtonGroup>
+        <Stack direction="row" alignItems="center" justifyContent="space-between" mb={1}>
+          <ButtonGroup variant="text">
+            <Button sx={{ width: "calc(8ch + 2rem)" }} onClick={togglePause}>{pausedRecords ? "Continue" : "Pause"}</Button>
+            <Button sx={{ width: "calc(8ch + 2rem)" }} onClick={clear}>{"Clear"}</Button>
+          </ButtonGroup>
+          <FormControlLabel label="Filter" control={(
+            <Switch checked={filterEnabled} onChange={e => setFilterEnabled(e.target.checked)} />
+          )} />
+        </Stack>
 
-
-        <div>
-          <Box my={2}>
-            <FormControlLabel label="Filter" control={(
-              <Switch checked={filterEnabled} onChange={e => setFilterEnabled(e.target.checked)} />
-            )} />
-            {filterEnabled && (
-              <Box bgcolor="#FAFAFA" border="1px solid rgba(63, 81, 181, 0.08)" borderRadius={1}>
-                <CodeMirror
-                  placeholder="Search through your logs records that include the following text"
-                  maxHeight="40vh"
-                  height="auto"
-                  onChange={filterChanged}
-                  extensions={[json(), linter(linterCallback)]}
-                  basicSetup={{ lineNumbers: false }} />
-              </Box>
-            )}
+        {filterEnabled && (
+          <Box bgcolor="#FAFAFA" border="1px solid rgba(63, 81, 181, 0.08)" borderRadius={1} my={2}>
+            <CodeMirror
+              placeholder="Search through your logs records that include the following text"
+              maxHeight="40vh"
+              height="auto"
+              onChange={filterChanged}
+              extensions={[json(), linter(linterCallback)]}
+              basicSetup={{ lineNumbers: false }} />
           </Box>
-          <FluentBitData records={getRecords()} />
-        </div>
+        )}
+
+        <FluentBitData records={getRecords()} />
       </StyledCard>
     </Box>
   )
@@ -218,13 +216,13 @@ function SampleCommands(props: SampleCommandsProps) {
             <Tab label="Curl" value="2" />
           </TabList>
         </Box>
-        <TabPanel value="1">
-          <Box bgcolor="#FAFAFA" border="1px solid rgba(63, 81, 181, 0.08)" borderRadius={1} padding={2} overflow="auto">
+        <TabPanel value="1" sx={{ pl: 0, pr: 0 }}>
+          <Box bgcolor="#FAFAFA" border="1px solid rgba(63, 81, 181, 0.08)" borderRadius={1} px={2} overflow="auto">
             <pre>{exampleFluentBitCommand(props.port)}</pre>
           </Box>
         </TabPanel>
-        <TabPanel value="2">
-          <Box bgcolor="#FAFAFA" border="1px solid rgba(63, 81, 181, 0.08)" borderRadius={1} padding={2} overflow="auto">
+        <TabPanel value="2" sx={{ pl: 0, pr: 0 }}>
+          <Box bgcolor="#FAFAFA" border="1px solid rgba(63, 81, 181, 0.08)" borderRadius={1} px={2} overflow="auto">
             <pre>{exampleCurlCommand(props.port)}</pre>
           </Box>
         </TabPanel>

--- a/ui/src/components/Vivo.tsx
+++ b/ui/src/components/Vivo.tsx
@@ -1,22 +1,29 @@
+import { json } from '@codemirror/lang-json'
+import { Diagnostic, linter } from "@codemirror/lint"
+import ArrowBackIosNew from "@mui/icons-material/ArrowBackIosNew"
 import UnfoldLess from "@mui/icons-material/UnfoldLess"
 import UnfoldMore from "@mui/icons-material/UnfoldMore"
+import TabContext from '@mui/lab/TabContext'
+import TabList from '@mui/lab/TabList'
+import TabPanel from '@mui/lab/TabPanel'
 import Box from "@mui/material/Box"
-import Checkbox from '@mui/material/Checkbox';
 import Button from "@mui/material/Button"
+import ButtonGroup from "@mui/material/ButtonGroup"
+import FormControlLabel from "@mui/material/FormControlLabel"
 import IconButton from "@mui/material/IconButton"
 import List from "@mui/material/List"
 import ListItem from "@mui/material/ListItem"
 import Stack from "@mui/material/Stack"
+import Switch from "@mui/material/Switch"
+import Tab from '@mui/material/Tab'
 import Typography from "@mui/material/Typography"
+import CodeMirror from '@uiw/react-codemirror'
 import { useEffect, useState } from 'react'
-import CodeMirror from '@uiw/react-codemirror';
-import { json } from '@codemirror/lang-json';
-import {linter, Diagnostic} from "@codemirror/lint"
-import { stringToIncludes, applyVivoFilter, Filter } from '../lib/filter'
-
+import { applyVivoFilter, Filter, stringToIncludes } from '../lib/filter'
 import {
-  VivoConnection, VivoStdoutEventData,
+  VivoConnection, VivoStdoutEventData
 } from '../lib/vivo'
+import StyledCard from "./StyledCard"
 
 interface VivoProps {
   connection: VivoConnection
@@ -40,7 +47,7 @@ export default function Vivo({
   connection, records, setViewData, clearRecords, filteredRecords, changeFilter, filter
 }: VivoProps) {
   const [currentPort, setCurrentPort] = useState(connection.currentPort())
-  const [pausedRecords, setPausedRecords] = useState<VivoStdoutEventData[] | null>(null);
+  const [pausedRecords, setPausedRecords] = useState<VivoStdoutEventData[] | null>(null)
   const [filterDiagnostics, setFilterDiagnostics] = useState([] as Diagnostic[])
   const [filterEnabled, setFilterEnabled] = useState(true)
 
@@ -50,11 +57,11 @@ export default function Vivo({
 
   function filterChanged(fstr: string) {
     if (fstr.trim() === '') {
-      return changeFilter(null);
+      return changeFilter(null)
     }
     try {
-      const filter = stringToIncludes(fstr);
-      changeFilter(filter);
+      const filter = stringToIncludes(fstr)
+      changeFilter(filter)
       setFilterDiagnostics([])
     } catch (err) {
       setFilterDiagnostics([{
@@ -62,23 +69,23 @@ export default function Vivo({
         to: 1,
         severity: 'error',
         message: err.message
-      }]);
+      }])
     }
   }
 
   function togglePause() {
     if (pausedRecords) {
-      setPausedRecords(null);
+      setPausedRecords(null)
     } else {
-      setPausedRecords(records.slice());
+      setPausedRecords(records.slice())
     }
   }
 
   function clear() {
     if (pausedRecords) {
-      setPausedRecords([]);
+      setPausedRecords([])
     } else {
-      clearRecords();
+      clearRecords()
     }
   }
 
@@ -103,40 +110,55 @@ export default function Vivo({
   }, [])
 
   return (
-    <div>
-      <div style={{ display: "flex", justifyContent: "space-between" }}>
-        <Button variant="contained" sx={{ backgroundColor: "#1669AA" }} onClick={() => setViewData(false)}>Go back</Button>
-        <Button variant="contained" sx={{ backgroundColor: "#1669AA" }} onClick={togglePause}>{ pausedRecords ? "Continue" : "Pause" }</Button>
-        <Button variant="contained" sx={{ backgroundColor: "#1669AA" }} onClick={clear}>{ "Clear" }</Button>
-      </div>
+    <Box mb={10}>
+      <StyledCard title="Live Data Viewer" subheader="All your events in only one space" action={(
+        <Box>
+          <Button sx={{ color: "#404186" }} startIcon={<ArrowBackIosNew />} onClick={() => {
+            setViewData(false)
+          }}>
+            Back
+          </Button>
+        </Box>
+      )}>
+        {currentPort !== null ? <>
+          <SampleCommands port={currentPort} />
+        </> : null}
 
-      {currentPort !== null ? <>
-        <p>Sample commands to post data:</p>
-        <pre>{exampleFluentBitCommand(currentPort)}</pre>
-        <pre>{exampleCurlCommand(currentPort)}</pre>
-      </> : null}
+        <ButtonGroup>
+          <Button variant="contained" sx={{ backgroundColor: "#1669AA", width: "calc(8ch + 2rem)" }} onClick={togglePause}>{pausedRecords ? "Continue" : "Pause"}</Button>
+          <Button variant="contained" sx={{ backgroundColor: "#1669AA", width: "calc(8ch + 2rem)" }} onClick={clear}>{"Clear"}</Button>
+        </ButtonGroup>
 
-      <div>
-      <Checkbox checked={filterEnabled} onChange={e => setFilterEnabled(e.target.checked)} />
-      <span>Filter:</span>
-      <CodeMirror
-        maxHeight="100px"
-        height="auto"
-        onChange={filterChanged}
-        extensions={[json(), linter(linterCallback)]}
-        basicSetup={{ lineNumbers: false }}/>
-      <FluentBitData connection={connection} records={getRecords()} />
-      </div>
-    </div>
+
+        <div>
+          <Box my={2}>
+            <FormControlLabel label="Filter" control={(
+              <Switch checked={filterEnabled} onChange={e => setFilterEnabled(e.target.checked)} />
+            )} />
+            {filterEnabled && (
+              <Box bgcolor="#FAFAFA" border="1px solid rgba(63, 81, 181, 0.08)" borderRadius={1}>
+                <CodeMirror
+                  placeholder="Search through your logs records that include the following text"
+                  maxHeight="40vh"
+                  height="auto"
+                  onChange={filterChanged}
+                  extensions={[json(), linter(linterCallback)]}
+                  basicSetup={{ lineNumbers: false }} />
+              </Box>
+            )}
+          </Box>
+          <FluentBitData records={getRecords()} />
+        </div>
+      </StyledCard>
+    </Box>
   )
 }
 
 interface FluentBitDataProps {
-  connection: VivoConnection
   records: VivoStdoutEventData[]
 }
 
-function FluentBitData({ records, connection }: FluentBitDataProps) {
+function FluentBitData({ records }: FluentBitDataProps) {
   const [foldMap, setFoldMap] = useState({})
 
   const onFold = id => {
@@ -171,6 +193,42 @@ function FluentBitData({ records, connection }: FluentBitDataProps) {
           )
         })}
       </List>
+    </Box>
+  )
+}
+
+type SampleCommandsProps = {
+  port: number
+}
+
+function SampleCommands(props: SampleCommandsProps) {
+  const [value, setValue] = useState('1')
+
+  const handleChange = (event: React.SyntheticEvent, newValue: string) => {
+    setValue(newValue)
+  }
+
+  return (
+    <Box sx={{ width: '100%', typography: 'body1' }}>
+      <Typography>Sample Commands to Send Data</Typography>
+      <TabContext value={value}>
+        <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+          <TabList onChange={handleChange} aria-label="lab API tabs example">
+            <Tab label="Fluent-Bit" value="1" />
+            <Tab label="Curl" value="2" />
+          </TabList>
+        </Box>
+        <TabPanel value="1">
+          <Box bgcolor="#FAFAFA" border="1px solid rgba(63, 81, 181, 0.08)" borderRadius={1} padding={2} overflow="auto">
+            <pre>{exampleFluentBitCommand(props.port)}</pre>
+          </Box>
+        </TabPanel>
+        <TabPanel value="2">
+          <Box bgcolor="#FAFAFA" border="1px solid rgba(63, 81, 181, 0.08)" borderRadius={1} padding={2} overflow="auto">
+            <pre>{exampleCurlCommand(props.port)}</pre>
+          </Box>
+        </TabPanel>
+      </TabContext>
     </Box>
   )
 }

--- a/ui/src/lib/filter.ts
+++ b/ui/src/lib/filter.ts
@@ -1,4 +1,4 @@
-import type { VivoStdoutEventData, } from './vivo'
+import type { VivoStdoutEventData } from './vivo'
 
 interface Includes {
   includes: string
@@ -26,7 +26,7 @@ export type Filter = Includes | Equals | Regex | Or | And
 
 function recordMatchesIncludes(includes: Includes, record: Record<string, unknown>): boolean {
   for (const [k, v] of Object.entries(record)) {
-    if (k.includes(includes.includes) || (typeof v === "string" && v.includes(includes.includes))) {
+    if (k.includes(includes.includes) || (String(v).includes(includes.includes))) {
       return true
     }
   }
@@ -44,7 +44,7 @@ function recordMatchesEquals(equals: Equals, record: Record<string, unknown>): b
 function recordMatchesRegex(regex: Regex, record: Record<string, unknown>): boolean {
   const value = record[regex.key]
   if (typeof value !== 'string') {
-    return false;
+    return false
   }
   return regex.matches.test(value)
 }
@@ -55,51 +55,51 @@ function recordMatchesOr(or: Or, record: Record<string, unknown>): boolean {
   for (const f of or.or) {
     rv = rv || recordMatchesFilter(f, record)
     if (rv) {
-      break;
+      break
     }
   }
 
-  return rv;
+  return rv
 }
 
 function recordMatchesAnd(and: And, record: Record<string, unknown>): boolean {
-  let rv = true;
+  let rv = true
 
   for (const f of and.and) {
     rv = rv && recordMatchesFilter(f, record)
     if (!rv) {
-      break;
+      break
     }
   }
 
-  return rv;
+  return rv
 }
 
 export function recordMatchesFilter(filter: Filter, record: Record<string, unknown>): boolean {
   if ('or' in filter) {
-    return recordMatchesOr(filter, record);
+    return recordMatchesOr(filter, record)
   } else if ('and' in filter) {
-    return recordMatchesAnd(filter, record);
+    return recordMatchesAnd(filter, record)
   } else if ('matches' in filter) {
-    return recordMatchesRegex(filter, record);
+    return recordMatchesRegex(filter, record)
   } else if ('includes' in filter) {
-    return recordMatchesIncludes(filter, record);
+    return recordMatchesIncludes(filter, record)
   } else {
-    return recordMatchesEquals(filter, record);
+    return recordMatchesEquals(filter, record)
   }
 }
 
 export function applyFilter(filter: Filter, records: Record<string, unknown>[]) {
-  return records.filter(r => recordMatchesFilter(filter, r));
+  return records.filter(r => recordMatchesFilter(filter, r))
 }
 
 export function applyVivoFilter(filter: Filter, records: VivoStdoutEventData[]) {
-  return records.filter(r => recordMatchesFilter(filter, r.data));
+  return records.filter(r => recordMatchesFilter(filter, r.data))
 }
 
 // Temporary hack that allows users to type in a filter without creating a proper query language
 export function jsonToFilter(json: string): Filter {
-  const parsed: unknown = JSON.parse(json);
+  const parsed: unknown = JSON.parse(json)
 
   function convert(obj: unknown): Filter {
     if (Array.isArray(obj['or'])) {
@@ -119,7 +119,7 @@ export function jsonToFilter(json: string): Filter {
     }
   }
 
-  return convert(parsed);
+  return convert(parsed)
 }
 
 export function stringToIncludes(str: string): Includes {


### PR DESCRIPTION
Wrapped Vivo UI in a styled card container.

Also improved includes filter to covert other types to string to do the matching; for example the number `92` in a log now can be matched using the filter `"92"`.

<img width="1920" alt="Screen Shot 2022-10-24 at 15 18 48" src="https://user-images.githubusercontent.com/7969166/197597300-ff5c30af-5716-442c-905b-afe1d26badec.png">
<img width="1920" alt="Screen Shot 2022-10-24 at 15 18 53" src="https://user-images.githubusercontent.com/7969166/197597304-bc48f42a-f89f-485d-864c-8453b5f41d81.png">


